### PR TITLE
Add error checking to state transition functions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Checkout Test Dependency Benedict

--- a/mutiny/actions.py
+++ b/mutiny/actions.py
@@ -247,7 +247,8 @@ class Exchange(QueuedAction):
         op1 = deck.pop()
         op2 = deck.pop()
         import mutiny.states.exchange
-        return mutiny.states.exchange.Exchange(data=self._data, exchange_options=(op1, op2))
+        exchange_options = tuple([inf.role for inf in self._data.active_player.hand if not inf.revealed]+[op1,op2])
+        return mutiny.states.exchange.Exchange(data=self._data, exchange_options=exchange_options)
 
     @property
     def action_name(self) -> ActionEnum:

--- a/mutiny/actions.py
+++ b/mutiny/actions.py
@@ -66,13 +66,17 @@ class QueuedTargetAction(QueuedAction):
 
     def __init__(self, data: GameData, target_id: int):
         super().__init__(data)
-        if not self._data.player_alive(target_id):
-            # Probably don't do this.
-            raise InvalidMove("Target is invalid")
-        if self._data.player_turn == target_id:
-            raise InvalidMove("Can not target yourself")
+        if (error := self.error_on_init(data, target_id)):
+            raise InvalidMove(error)
 
         self._target_id = target_id
+
+    @classmethod
+    def error_on_init(cls, data, target_id):
+        if not data.player_alive(target_id):
+            return "Target is invalid"
+        if data.player_turn == target_id:
+            return "Can not target yourself"
 
     @property
     def can_be_blocked(self) -> bool:

--- a/mutiny/state_interface.py
+++ b/mutiny/state_interface.py
@@ -5,9 +5,10 @@ from mutiny.game_data import GameData
 from mutiny.game_enum import StateEnum, RoleEnum
 from mutiny.exceptions import InvalidMove
 
+INVALID_TRANSITION = "Cannot %s on %s"
 
 class StateInterface(ABC):
-    """ Superclass for ways that GameData can be modified.
+    """ Superclass for ways that GameData error_on be modified.
     Extend this class to implement game logic. All methods
     that modify game data return a (possibly new) StateInterface
     that wraps it. Essentially a state machine. """
@@ -45,82 +46,82 @@ class StateInterface(ABC):
         self._data.reset()
         return mutiny.states.player_turn.PlayerTurn(data=self._data)
 
-    def can_noop(self, player_id: int) -> bool:
-        return False
+    def error_on_noop(self, player_id: int) -> Union[None, str]:
+        return INVALID_TRANSITION % ("noop", self.state_name)
 
     def noop(self, player_id: int) -> "StateInterface":
         """ For Benedict (The AI). """
-        pass
+        raise InvalidMove(self.error_on_noop(player_id))
 
-    def can_income(self, player_id: int) -> bool:
-        return False
+    def error_on_income(self, player_id: int) -> Union[None, str]:
+        return INVALID_TRANSITION % ("income", self.state_name)
 
     def income(self, player_id: int) -> "StateInterface":
-        raise InvalidMove("Cannot take income on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_income(player_id))
 
-    def can_faid(self, player_id: int) -> bool:
-        return False
+    def error_on_faid(self, player_id: int) -> Union[None, str]:
+        return INVALID_TRANSITION % ("foreign aid", self.state_name)
 
     def f_aid(self, player_id: int) -> "StateInterface":
-        raise InvalidMove("Cannot take foreign aid on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_faid(player_id))
 
-    def can_tax(self, player_id: int) -> bool:
-        return False
+    def error_on_tax(self, player_id: int) -> Union[None, str]:
+        return INVALID_TRANSITION % ("tax", self.state_name)
 
     def tax(self, player_id: int) -> "StateInterface":
-        raise InvalidMove("Cannot tax on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_tax(player_id))
 
-    def can_assassinate(self, player_id: int, target_id: int) -> bool:
-        return False
+    def error_on_assassinate(self, player_id: int, target_id: int) -> Union[None, str]:
+        return INVALID_TRANSITION % ("assassinate", self.state_name)
 
     def assassinate(self, player_id: int, target_id: int) -> "StateInterface":
-        raise InvalidMove("Cannot assassinate on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_assassinate(player_id))
 
-    def can_steal(self, player_id: int, target_id: int) -> bool:
-        return False
+    def error_on_steal(self, player_id: int, target_id: int) -> Union[None, str]:
+        return INVALID_TRANSITION % ("steal", self.state_name)
 
     def steal(self, player_id: int, target_id: int) -> "StateInterface":
-        raise InvalidMove("Cannot steal on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_steal(player_id))
 
-    def can_coup(self, player_id: int, target_id: int) -> bool:
-        return False
+    def error_on_coup(self, player_id: int, target_id: int) -> Union[None, str]:
+        return INVALID_TRANSITION % ("coup", self.state_name)
 
     def coup(self, player_id: int, target_id: int) -> "StateInterface":
-        raise InvalidMove("Cannot coup on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_coup(player_id))
 
-    def can_exchange(self, player_id: int) -> "StateInterface":
-        return False
+    def error_on_exchange(self, player_id: int) -> "StateInterface":
+        return INVALID_TRANSITION % ("exchange", self.state_name)
 
     def exchange(self, player_id: int) -> "StateInterface":
-        raise InvalidMove("Cannot perform exchange action on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_exchange(player_id))
 
-    def can_challenge(self, player_id: int) -> bool:
-        return False
+    def error_on_challenge(self, player_id: int) -> Union[None, str]:
+        return INVALID_TRANSITION % ("challenge", self.state_name)
 
     def challenge(self, player_id: int) -> "StateInterface":
-        raise InvalidMove("Cannot challenge on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_challenge(player_id))
 
-    def can_block(self, player_id: int, blocking_role: RoleEnum) -> bool:
-        return False
+    def error_on_block(self, player_id: int, blocking_role: RoleEnum) -> Union[None, str]:
+        return INVALID_TRANSITION % ("block", self.state_name)
 
     def block(self, player_id: int, blocking_role: RoleEnum) -> "StateInterface":
-        raise InvalidMove("Cannot block on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_block(player_id))
 
-    def can_allow(self, player_id: int) -> bool:
-        return False
+    def error_on_allow(self, player_id: int) -> Union[None, str]:
+        return INVALID_TRANSITION % ("allow", self.state_name)
 
     def allow(self, player_id: int) -> "StateInterface":
         """ Any form of synchronization should be performed outside of this class. """
-        raise InvalidMove("Cannot allow on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_allow(player_id))
 
-    def can_reveal(self, player_id: int, influence: RoleEnum) -> bool:
-        return False
+    def error_on_reveal(self, player_id: int, influence: RoleEnum) -> Union[None, str]:
+        return INVALID_TRANSITION % ("reveal", self.state_name)
 
     def reveal(self, player_id: int, influence: RoleEnum) -> "StateInterface":
-        raise InvalidMove("Cannot reveal on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_reveal(player_id))
 
-    def can_replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> bool:
-        return False
+    def error_on_replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> Union[None, str]:
+        return INVALID_TRANSITION % ("replace", self.state_name)
 
     def replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> "StateInterface":
-        raise InvalidMove("Cannot replace cards on {}".format(self.state_name))
+        raise InvalidMove(self.error_on_replace(player_id))

--- a/mutiny/state_interface.py
+++ b/mutiny/state_interface.py
@@ -75,19 +75,19 @@ class StateInterface(ABC):
         return INVALID_TRANSITION % ("assassinate", self.state_name)
 
     def assassinate(self, player_id: int, target_id: int) -> "StateInterface":
-        raise InvalidMove(self.error_on_assassinate(player_id))
+        raise InvalidMove(self.error_on_assassinate(player_id, target_id))
 
     def error_on_steal(self, player_id: int, target_id: int) -> Union[None, str]:
         return INVALID_TRANSITION % ("steal", self.state_name)
 
     def steal(self, player_id: int, target_id: int) -> "StateInterface":
-        raise InvalidMove(self.error_on_steal(player_id))
+        raise InvalidMove(self.error_on_steal(player_id, target_id))
 
     def error_on_coup(self, player_id: int, target_id: int) -> Union[None, str]:
         return INVALID_TRANSITION % ("coup", self.state_name)
 
     def coup(self, player_id: int, target_id: int) -> "StateInterface":
-        raise InvalidMove(self.error_on_coup(player_id))
+        raise InvalidMove(self.error_on_coup(player_id, target_id))
 
     def error_on_exchange(self, player_id: int) -> "StateInterface":
         return INVALID_TRANSITION % ("exchange", self.state_name)
@@ -105,7 +105,7 @@ class StateInterface(ABC):
         return INVALID_TRANSITION % ("block", self.state_name)
 
     def block(self, player_id: int, blocking_role: RoleEnum) -> "StateInterface":
-        raise InvalidMove(self.error_on_block(player_id))
+        raise InvalidMove(self.error_on_block(player_id, blocking_role))
 
     def error_on_allow(self, player_id: int) -> Union[None, str]:
         return INVALID_TRANSITION % ("allow", self.state_name)
@@ -118,10 +118,10 @@ class StateInterface(ABC):
         return INVALID_TRANSITION % ("reveal", self.state_name)
 
     def reveal(self, player_id: int, influence: RoleEnum) -> "StateInterface":
-        raise InvalidMove(self.error_on_reveal(player_id))
+        raise InvalidMove(self.error_on_reveal(player_id, influence))
 
     def error_on_replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> Union[None, str]:
         return INVALID_TRANSITION % ("replace", self.state_name)
 
     def replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> "StateInterface":
-        raise InvalidMove(self.error_on_replace(player_id))
+        raise InvalidMove(self.error_on_replace(player_id, influences))

--- a/mutiny/state_interface.py
+++ b/mutiny/state_interface.py
@@ -15,7 +15,7 @@ class StateInterface(ABC):
     def __init__(self, *, data: GameData):
         self._data = data
         self._data.state_id += 1
-    
+
     @property
     def state_id(self) -> int:
         return self._data.state_id
@@ -46,43 +46,82 @@ class StateInterface(ABC):
         return mutiny.states.player_turn.PlayerTurn(data=self._data)
 
     @abstractmethod
+    def can_noop(self, player_id: int) -> bool:
+        return False
+
     def noop(self, player_id: int) -> "StateInterface":
         """ For Benedict (The AI). """
         pass
 
+    def can_income(self, player_id: int) -> bool:
+        return False
+
     def income(self, player_id: int) -> "StateInterface":
         raise InvalidMove("Cannot take income on {}".format(self.state_name))
+
+    def can_faid(self, player_id: int) -> bool:
+        return False
 
     def f_aid(self, player_id: int) -> "StateInterface":
         raise InvalidMove("Cannot take foreign aid on {}".format(self.state_name))
 
+    def can_tax(self, player_id: int) -> bool:
+        return False
+
     def tax(self, player_id: int) -> "StateInterface":
         raise InvalidMove("Cannot tax on {}".format(self.state_name))
+
+    def can_assassinate(self, player_id: int, target_id: int) -> bool:
+        return False
 
     def assassinate(self, player_id: int, target_id: int) -> "StateInterface":
         raise InvalidMove("Cannot assassinate on {}".format(self.state_name))
 
+    def can_steal(self, player_id: int) -> bool:
+        return False
+
     def steal(self, player_id: int, target_id: int) -> "StateInterface":
         raise InvalidMove("Cannot steal on {}".format(self.state_name))
+
+    def can_coup(self, player_id: int, target_id: int) -> bool:
+        return False
 
     def coup(self, player_id: int, target_id: int) -> "StateInterface":
         raise InvalidMove("Cannot coup on {}".format(self.state_name))
 
+    def can_exchange(self, player_id: int) -> "StateInterface":
+        return False
+
     def exchange(self, player_id: int) -> "StateInterface":
         raise InvalidMove("Cannot perform exchange action on {}".format(self.state_name))
+
+    def can_challenge(self, player_id: int) -> bool:
+        return False
 
     def challenge(self, player_id: int) -> "StateInterface":
         raise InvalidMove("Cannot challenge on {}".format(self.state_name))
 
+    def can_block(self, player_id: int, blocking_role: RoleEnum) -> bool:
+        return False
+
     def block(self, player_id: int, blocking_role: RoleEnum) -> "StateInterface":
         raise InvalidMove("Cannot block on {}".format(self.state_name))
+
+    def can_allow(self, player_id: int) -> bool:
+        return False
 
     def allow(self, player_id: int) -> "StateInterface":
         """ Any form of synchronization should be performed outside of this class. """
         raise InvalidMove("Cannot allow on {}".format(self.state_name))
 
+    def can_reveal(self, player_id: int, influence: RoleEnum) -> bool:
+        return False
+
     def reveal(self, player_id: int, influence: RoleEnum) -> "StateInterface":
         raise InvalidMove("Cannot reveal on {}".format(self.state_name))
+
+    def replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> bool:
+        return False
 
     def replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> "StateInterface":
         raise InvalidMove("Cannot replace cards on {}".format(self.state_name))

--- a/mutiny/state_interface.py
+++ b/mutiny/state_interface.py
@@ -59,11 +59,11 @@ class StateInterface(ABC):
     def income(self, player_id: int) -> "StateInterface":
         raise InvalidMove(self.error_on_income(player_id))
 
-    def error_on_faid(self, player_id: int) -> Union[None, str]:
+    def error_on_f_aid(self, player_id: int) -> Union[None, str]:
         return INVALID_TRANSITION % ("foreign aid", self.state_name)
 
     def f_aid(self, player_id: int) -> "StateInterface":
-        raise InvalidMove(self.error_on_faid(player_id))
+        raise InvalidMove(self.error_on_f_aid(player_id))
 
     def error_on_tax(self, player_id: int) -> Union[None, str]:
         return INVALID_TRANSITION % ("tax", self.state_name)

--- a/mutiny/state_interface.py
+++ b/mutiny/state_interface.py
@@ -8,7 +8,7 @@ from mutiny.exceptions import InvalidMove
 INVALID_TRANSITION = "Cannot %s on %s"
 
 class StateInterface(ABC):
-    """ Superclass for ways that GameData error_on be modified.
+    """ Superclass for ways that GameData can be modified.
     Extend this class to implement game logic. All methods
     that modify game data return a (possibly new) StateInterface
     that wraps it. Essentially a state machine. """

--- a/mutiny/state_interface.py
+++ b/mutiny/state_interface.py
@@ -120,7 +120,7 @@ class StateInterface(ABC):
     def reveal(self, player_id: int, influence: RoleEnum) -> "StateInterface":
         raise InvalidMove("Cannot reveal on {}".format(self.state_name))
 
-    def replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> bool:
+    def can_replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> bool:
         return False
 
     def replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum, None]]) -> "StateInterface":

--- a/mutiny/state_interface.py
+++ b/mutiny/state_interface.py
@@ -45,7 +45,6 @@ class StateInterface(ABC):
         self._data.reset()
         return mutiny.states.player_turn.PlayerTurn(data=self._data)
 
-    @abstractmethod
     def can_noop(self, player_id: int) -> bool:
         return False
 
@@ -77,7 +76,7 @@ class StateInterface(ABC):
     def assassinate(self, player_id: int, target_id: int) -> "StateInterface":
         raise InvalidMove("Cannot assassinate on {}".format(self.state_name))
 
-    def can_steal(self, player_id: int) -> bool:
+    def can_steal(self, player_id: int, target_id: int) -> bool:
         return False
 
     def steal(self, player_id: int, target_id: int) -> "StateInterface":

--- a/mutiny/states/exchange.py
+++ b/mutiny/states/exchange.py
@@ -27,7 +27,7 @@ class Exchange(StateInterface):
         d = super().to_dict(player_id)
         d["state"]["action"] = ActionEnum.EXCHANGE.value
         if player_id in [None, self._data.player_turn]:
-            d["state"]["exchangeOptions"] = [o.value for o in self.exchange_options] + [o.role.value for o in self._data.active_player.hand if not o.revealed]
+            d["state"]["exchangeOptions"] = [o.value for o in self.exchange_options]
         return d
 
     def error_on_noop(self, player_id: int) -> Union[None, str]:
@@ -42,6 +42,7 @@ class Exchange(StateInterface):
 
     def error_on_replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum]]) -> Union[None, str]:
         if player_id != self._data.player_turn:
+            print(player_id, self._data.player_turn)
             return "Wrong player to exchange"
 
         player = self._data.active_player
@@ -52,7 +53,7 @@ class Exchange(StateInterface):
             return "Player can only keep as many cards as influence they have."
 
         # check influences to keep are valid (in the player's hand or in the player's exchange options)
-        cards_can_keep = [influence.role for influence in player.hand if not influence.revealed] + list(self.exchange_options)
+        cards_can_keep = [role for role in self.exchange_options]
         for role in cards_to_keep:
             if role not in cards_can_keep:
                 return "Exchange attempt invalid due to role choice."
@@ -67,7 +68,7 @@ class Exchange(StateInterface):
         player = self._data.active_player
 
         cards_to_keep = [role for role in influences]
-        cards_can_keep = [influence.role for influence in player.hand if not influence.revealed] + list(self.exchange_options)
+        cards_can_keep = [role for role in self.exchange_options]
 
         for role in cards_to_keep:
             cards_can_keep.remove(role)

--- a/mutiny/states/exchange.py
+++ b/mutiny/states/exchange.py
@@ -38,7 +38,7 @@ class Exchange(StateInterface):
             raise InvalidMove(f"Player {player_id} must replace on {self.state_name}")
         return self
 
-    def can_replace(self, player_id: int, influences: Tuple[RoleENum, Union[RoleEnum]]) -> bool:
+    def can_replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum]]) -> bool:
         if player_id != self._data.player_turn:
             return False
 

--- a/mutiny/states/exchange.py
+++ b/mutiny/states/exchange.py
@@ -62,7 +62,7 @@ class Exchange(StateInterface):
 
     def replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum]]) -> StateInterface:
         if (error := self.error_on_replace(player_id, influences)):
-            raise InvalideMove(error)
+            raise InvalidMove(error)
 
         player = self._data.active_player
 

--- a/mutiny/states/exchange.py
+++ b/mutiny/states/exchange.py
@@ -42,7 +42,6 @@ class Exchange(StateInterface):
 
     def error_on_replace(self, player_id: int, influences: Tuple[RoleEnum, Union[RoleEnum]]) -> Union[None, str]:
         if player_id != self._data.player_turn:
-            print(player_id, self._data.player_turn)
             return "Wrong player to exchange"
 
         player = self._data.active_player

--- a/mutiny/states/player_turn.py
+++ b/mutiny/states/player_turn.py
@@ -37,7 +37,7 @@ class PlayerTurn(StateInterface):
         return StateEnum.START_TURN
 
     def can_noop(self, player_id: int) -> bool:
-        return not self._is_turn(player_id):
+        return not self._is_turn(player_id)
 
     def noop(self, player_id: int) -> StateInterface:
         if not self.can_noop(player_id):

--- a/mutiny/states/player_turn.py
+++ b/mutiny/states/player_turn.py
@@ -20,6 +20,11 @@ class PlayerTurn(StateInterface):
     def state_name(self) -> StateEnum:
         return StateEnum.START_TURN
 
+    def can_noop(self, player_id: int) -> bool:
+        if player_id == self._data.player_turn:
+            return False
+        return True
+
     def noop(self, player_id: int) -> StateInterface:
         if player_id == self._data.player_turn:
             raise InvalidMove(f"Player {player_id} must make a move on {self.state_name}")

--- a/mutiny/states/player_turn.py
+++ b/mutiny/states/player_turn.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from mutiny.state_interface import StateInterface
 from mutiny.actions import ForeignAid, Income, Coup, Steal, Tax, Assassinate, Exchange
 from mutiny.exceptions import InvalidMove
@@ -11,110 +13,116 @@ class PlayerTurn(StateInterface):
     # The following pairs of functions both check for the same things
     # however the bottom two raise an exception
 
-    def _is_turn(self, player_id: int):
+    def _is_turn(self, player_id: int) -> bool:
         return self._data.player_turn == player_id
 
     def _must_coup(self) -> bool:
         return self._data.active_player.must_coup
 
-    def can_make_non_coup(self, player_id: int):
-        if not self._is_turn(player_id) or self._must_coup():
-            return False
-        return True
-
-    def _checkTurn(self, player_id: int) -> None:
+    # helper function that returns the error message for non-coup actions
+    def error_on_not_coup(self, player_id) -> Union[None, str]:
         if not self._is_turn(player_id):
-            raise InvalidMove("Not {}'s turn".format(self._data.players[player_id].name))
-
-    def _checkCoup(self) -> None:
+            return "Not {}'s turn".format(self._data.players[player_id].name)
         if self._must_coup():
-            raise InvalidMove("{} must coup".format(self._data.active_player.name))
-
-
+            return "{} must coup".format(self._data.active_player.name)
+        return None
 
     @property
     def state_name(self) -> StateEnum:
         return StateEnum.START_TURN
 
-    def can_noop(self, player_id: int) -> bool:
-        return not self._is_turn(player_id)
+    def error_on_noop(self, player_id: int) -> Union[None, str]:
+        if self._is_turn(player_id):
+            return f"Player {player_id} must make a move on {self.state_name}"
+        return None
 
     def noop(self, player_id: int) -> StateInterface:
-        if not self.can_noop(player_id):
-            raise InvalidMove(f"Player {player_id} must make a move on {self.state_name}")
+        if (error := self.error_on_noop(player_id)):
+            raise InvalidMove(error)
         return self
 
-    def can_income(self, player_id: int) -> bool:
-        return self.can_make_non_coup(player_id)
+    def error_on_income(self, player_id: int) -> Union[None, str]:
+        return self.error_on_not_coup(player_id)
 
     def income(self, player_id: int) -> StateInterface:
-        self._checkTurn(player_id)
-        self._checkCoup()
+        if (error := self.error_on_income(player_id)):
+            raise InvalidMove(error)
         return Income(self._data).resolve()
 
-    def can_f_aid(self, player_id: int) -> bool:
-        return self.can_make_non_coup(player_id)
+    def error_on_f_aid(self, player_id: int) -> Union[None, str]:
+        return self.error_on_not_coup(player_id)
 
     def f_aid(self, player_id: int) -> StateInterface:
-        self._checkTurn(player_id)
-        self._checkCoup()
+        if (error := self.error_on_tax(player_id)):
+            raise InvalidMove(error)
 
         queued = ForeignAid(self._data)
         return WaitForActionResponse(data=self._data, action=queued)  # no action role used for fAid
 
-    def can_tax(self, player_id: int) -> bool:
-        return self.can_make_non_coup(player_id)
+    def error_on_tax(self, player_id: int) -> Union[None, str]:
+        return self.error_on_not_coup(player_id)
 
     def tax(self, player_id: int) -> StateInterface:
-        self._checkTurn(player_id)
-        self._checkCoup()
+        if (error := self.error_on_tax(player_id)):
+            raise InvalidMove(error)
 
         queued = Tax(self._data)
         return WaitForActionResponse(data=self._data, action=queued)
 
-    def can_assassinate(self, player_id: int, target_id: int) -> bool:
-        return self.can_make_non_coup(player_id) and self._data.active_player.cash >= ASSASSINATE_COST and self._data.players[target_id].alive
+    def error_on_assassinate(self, player_id: int, target_id: int) -> Union[None, str]:
+        if (error := self.error_on_not_coup(player_id)):
+            return error
+        if self._data.active_player.cash < ASSASSINATE_COST:
+            return "{} does not have enough cash to assassinate".format(self._data.active_player.name)
+        if (error := Assassinate.error_on_init(self._data, target_id)):
+            return error
+        return None
 
     def assassinate(self, player_id: int, target_id: int) -> StateInterface:
-        self._checkTurn(player_id)
-        self._checkCoup()
-        if self._data.active_player.cash < ASSASSINATE_COST:
-            raise InvalidMove("{} does not have enough cash to assassinate".format(self._data.active_player.name))
-        queued = Assassinate(self._data, target_id) # constructor checks if target is valid
+        if (error := self.error_on_assassinate(player_id, target_id)):
+            raise InvalidMove(error)
 
+        queued = Assassinate(self._data, target_id) # NOTE: targeted_action constructor also checks if target is valid
         self._data.active_player.removeCash(ASSASSINATE_COST)
         return WaitForActionResponse(data=self._data, action=queued)
 
-    def can_steal(self, player_id: int, target_id: int) -> bool:
-        return self.can_make_non_coup(player_id) and self._data.players[target_id].alive
+    def error_on_steal(self, player_id: int, target_id: int) -> Union[None, str]:
+        if (error := self.error_on_not_coup(player_id)):
+            return error
+        if (error := Steal.error_on_init(self._data, target_id)):
+            return error
+        return None
 
     def steal(self, player_id: int, target_id: int) -> StateInterface:
-        self._checkTurn(player_id)
-        self._checkCoup()
-        queued = Steal(self._data, target_id)
+        if (error := self.error_on_steal(player_id, target_id)):
+            raise InvalidMove(error)
 
+        queued = Steal(self._data, target_id)
         return WaitForActionResponse(data=self._data, action=queued)
 
-    def can_exchange(self, player_id: int) -> bool:
-        return self.can_make_non_coup(player_id)
+    def error_on_exchange(self, player_id: int) -> Union[None, str]:
+        return self.error_on_not_coup(player_id)
 
     def exchange(self, player_id: int) -> StateInterface:
-        self._checkTurn(player_id)
-        self._checkCoup()
+        if (error := self.error_on_exchange(player_id)):
+            raise InvalidMove(error)
 
         queued = Exchange(self._data)
         return WaitForActionResponse(data=self._data, action=queued)
 
-
-    def can_coup(self, player_id: int, target_id: int) -> bool:
-        return self.can_make_non_coup(player_id) and self._data.active_player.cash >= COUP_COST and self._data.players[target_id].alive
-
+    def error_on_coup(self, player_id: int, target_id: int) -> Union[None, str]:
+        if not self._is_turn(player_id):
+            return "Not {}'s turn".format(self._data.players[player_id].name)
+        if (self._data.active_player.cash < COUP_COST):
+            return "{} does not have enough cash to coup".format(self._data.active_player.name)
+        if (error := Coup.error_on_init(self._data, target_id)):
+            return error
+        return None
 
     def coup(self, player_id: int, target_id: int) -> StateInterface:
-        self._checkTurn(player_id)
-        if self._data.active_player.cash < COUP_COST:
-            raise InvalidMove("{} does not have enough cash to coup".format(self._data.active_player.name))
-        action = Coup(self._data, target_id) # constructor checks if target is valid
+        if (error := self.error_on_coup(player_id, target_id)):
+            raise InvalidMove(error)
 
+        action = Coup(self._data, target_id)
         self._data.active_player.removeCash(COUP_COST)
         return action.resolve() # Returns reveal state with no action queued

--- a/mutiny/states/player_turn.py
+++ b/mutiny/states/player_turn.py
@@ -1,7 +1,7 @@
 from mutiny.state_interface import StateInterface
 from mutiny.actions import ForeignAid, Income, Coup, Steal, Tax, Assassinate, Exchange
 from mutiny.exceptions import InvalidMove
-from mutiny.game_enum import StateEnum
+from mutiny.game_enum import StateEnum, ActionEnum
 from mutiny.states.wait_for_action_response import WaitForActionResponse
 from mutiny.constants import COUP_COST, ASSASSINATE_COST
 
@@ -45,7 +45,7 @@ class PlayerTurn(StateInterface):
         return self
 
     def can_income(self, player_id: int) -> bool:
-        return can_make_non_coup(player_id)
+        return self.can_make_non_coup(player_id)
 
     def income(self, player_id: int) -> StateInterface:
         self._checkTurn(player_id)
@@ -53,7 +53,7 @@ class PlayerTurn(StateInterface):
         return Income(self._data).resolve()
 
     def can_f_aid(self, player_id: int) -> bool:
-        return can_make_non_coup(player_id)
+        return self.can_make_non_coup(player_id)
 
     def f_aid(self, player_id: int) -> StateInterface:
         self._checkTurn(player_id)
@@ -63,7 +63,7 @@ class PlayerTurn(StateInterface):
         return WaitForActionResponse(data=self._data, action=queued)  # no action role used for fAid
 
     def can_tax(self, player_id: int) -> bool:
-        return can_make_non_coup(player_id)
+        return self.can_make_non_coup(player_id)
 
     def tax(self, player_id: int) -> StateInterface:
         self._checkTurn(player_id)
@@ -73,7 +73,7 @@ class PlayerTurn(StateInterface):
         return WaitForActionResponse(data=self._data, action=queued)
 
     def can_assassinate(self, player_id: int, target_id: int) -> bool:
-        return can_make_non_coup(player_id) and self._data.active_player.cash >= ASSASSINATE_COST
+        return self.can_make_non_coup(player_id) and self._data.active_player.cash >= ASSASSINATE_COST and self._data.players[target_id].alive
 
     def assassinate(self, player_id: int, target_id: int) -> StateInterface:
         self._checkTurn(player_id)
@@ -86,7 +86,7 @@ class PlayerTurn(StateInterface):
         return WaitForActionResponse(data=self._data, action=queued)
 
     def can_steal(self, player_id: int, target_id: int) -> bool:
-        return can_make_non_coup(player_id)
+        return self.can_make_non_coup(player_id) and self._data.players[target_id].alive
 
     def steal(self, player_id: int, target_id: int) -> StateInterface:
         self._checkTurn(player_id)
@@ -96,7 +96,7 @@ class PlayerTurn(StateInterface):
         return WaitForActionResponse(data=self._data, action=queued)
 
     def can_exchange(self, player_id: int) -> bool:
-        return can_make_non_coup(player_id)
+        return self.can_make_non_coup(player_id)
 
     def exchange(self, player_id: int) -> StateInterface:
         self._checkTurn(player_id)
@@ -107,7 +107,7 @@ class PlayerTurn(StateInterface):
 
 
     def can_coup(self, player_id: int, target_id: int) -> bool:
-        return can_make_non_coup(player_id) and self._data.active_player.cash >= COUP_COST
+        return self.can_make_non_coup(player_id) and self._data.active_player.cash >= COUP_COST and self._data.players[target_id].alive
 
 
     def coup(self, player_id: int, target_id: int) -> StateInterface:

--- a/mutiny/states/player_turn.py
+++ b/mutiny/states/player_turn.py
@@ -53,7 +53,7 @@ class PlayerTurn(StateInterface):
         return self.error_on_not_coup(player_id)
 
     def f_aid(self, player_id: int) -> StateInterface:
-        if (error := self.error_on_tax(player_id)):
+        if (error := self.error_on_f_aid(player_id)):
             raise InvalidMove(error)
 
         queued = ForeignAid(self._data)

--- a/mutiny/states/reveal.py
+++ b/mutiny/states/reveal.py
@@ -74,10 +74,20 @@ class Reveal(StateInterface):
         d["state"]["playerToReveal"] = self._reveal_player.self_id
         return d
 
+    def can_noop(self, player_id: int) -> bool:
+        return player_id != self._reveal_id
+
     def noop(self, player_id: int) -> StateInterface:
-        if player_id == self._reveal_id:
+        if not self.can_noop(player_id):
             raise InvalidMove(f"Player {player_id} must reveal on {self.state_name}")
         return self
+
+    def can_reveal(self, player_id: int, influence: RoleEnum) -> bool:
+        if player_id != self._reveal_id:
+            return False
+        if not self._reveal_player.hasAliveInfluence(influence):
+            return False
+        return True
 
     def reveal(self, player_id: int, influence: RoleEnum) -> StateInterface:
         if player_id != self._reveal_id:

--- a/mutiny/states/wait_for_action_response.py
+++ b/mutiny/states/wait_for_action_response.py
@@ -44,7 +44,7 @@ class WaitForActionResponse(StateInterface):
         return d
 
     def can_challenge(self, player_id: int) -> bool:
-        if self.allow[player_id]:
+        if self._allow[player_id]:
             return False
         if not self._action.can_be_challenged:
             return False

--- a/mutiny/states/wait_for_action_response.py
+++ b/mutiny/states/wait_for_action_response.py
@@ -30,6 +30,9 @@ class WaitForActionResponse(StateInterface):
     def state_name(self) -> StateEnum:
         return StateEnum.WAIT_FOR_ACTION_RESPONSE
 
+    def can_noop(self, player_id: int) -> bool:
+        return self._data.player_turn == player_id
+        
     def noop(self, player_id: int) -> StateInterface:
         # If player has not already implicitly allowed
         if not self._allow[player_id]:

--- a/mutiny/states/wait_for_action_response.py
+++ b/mutiny/states/wait_for_action_response.py
@@ -104,7 +104,7 @@ class WaitForActionResponse(StateInterface):
                                     block_role=blocking_role)
 
     def can_allow(self, player_id: int) -> bool:
-        return not self._allow[player_id]:
+        return not self._allow[player_id]
 
     def allow(self, player_id: int) -> StateInterface:
         if self._allow[player_id]:

--- a/mutiny/states/wait_for_block.py
+++ b/mutiny/states/wait_for_block.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Union
 
 from mutiny.actions import QueuedAction, QueuedTargetAction
 from mutiny.game_enum import ActionEnum, StateEnum, RoleEnum
@@ -40,49 +40,47 @@ class WaitForBlock(StateInterface):
     def state_name(self) -> StateEnum:
         return StateEnum.WAIT_FOR_BLOCK
 
-    def can_noop(self, player_id: int) -> bool:
+    def error_on_noop(self, player_id: int) -> Union[None, str]:
         # If player has not already implicitly allowed
         if not self._allow[player_id] and (self._action.action_name == ActionEnum.F_AID or self._action.target == player_id):
             # Can only block duke, or block something targeted at you
-            return False
-        return True
+            return f"Player {player_id} must allow or block on {self.state_name}"
+        return None
 
     def noop(self, player_id: int) -> StateInterface:
-        if not self.can_noop(player_id):
-            raise InvalidMove(f"Player {player_id} must allow or block on {self.state_name}")
+        if (error := self.error_on_noop(player_id)):
+            raise InvalidMove(error)
         return self
 
-    def can_block(self, player_id: int, blocking_role: RoleEnum) -> bool:
+    def error_on_block(self, player_id: int, blocking_role: RoleEnum) -> Union[None, str]:
         if self._allow[player_id]:
-            return False
+            return "Player has already implicitly allowed the action"
         if blocking_role not in BLOCKING_ROLES[self._action.action_name]:
-            return False
+            return "Cannot block {} with {}".format(self._action.action_name, blocking_role)
         if blocking_role != RoleEnum.DUKE and player_id != self._action.target:
-            return False
-        return True
+            return "Cannot block if you are not the target"
+        return None
 
     def block(self, player_id: int, blocking_role: RoleEnum) -> StateInterface:
-        if self._allow[player_id]:
-            raise InvalidMove("Player has already implicitly allowed the action")
-        if blocking_role not in BLOCKING_ROLES[self._action.action_name]:
-            raise InvalidMove("Cannot block {} with {}".format(self._action.action_name, blocking_role))
-        if blocking_role != RoleEnum.DUKE and player_id != self._action.target:
-            raise InvalidMove("Cannot block if you are not the target")
+        if (error := self.error_on_block(player_id, blocking_role)):
+            raise InvalidMove(error)
 
         return WaitForBlockResponse(data=self._data,
                                     action=self._action,
                                     blocker_id=player_id,
                                     block_role=blocking_role)
 
-    def can_allow(self, player_id: int) -> bool:
-        return not self._allow[player_id]
+    def error_on_allow(self, player_id: int) -> Union[None, str]:
+        if self._allow[player_id]:
+            return "Player has already implicitly allowed the action"
+        return None
 
     def allow(self, player_id: int) -> StateInterface:
-        if self._allow[player_id]:
-            raise InvalidMove("Player has already implicitly allowed the action")
-        self._allow[player_id] = True
+        if (error := self.error_on_allow(player_id)):
+            raise InvalidMove(error)
 
         # targeted actions only require permission of the target after a challenge
+        self._allow[player_id] = True
         if isinstance(self._action, QueuedTargetAction) and self._allow[self._action.target]:
             return self._action.resolve()
         if all(self._allow):

--- a/mutiny/states/wait_for_block_response.py
+++ b/mutiny/states/wait_for_block_response.py
@@ -37,11 +37,17 @@ class WaitForBlockResponse(StateInterface):
         d["state"]["blockingRole"] = self._block_role.value
         return d
 
+    def can_noop(self, player_id: int) -> bool:
+        return self._allow[player_id]
+
     def noop(self, player_id: int) -> StateInterface:
         # If player has not already implicitly allowed
         if not self._allow[player_id]:
             raise InvalidMove(f"Player {player_id} must allow or challenge on {self.state_name}")
         return self
+
+    def can_challenge(self, player_id: int) -> bool:
+        return not self._allow[player_id]
 
     def challenge(self, player_id: int) -> StateInterface:
         if self._allow[player_id]:
@@ -60,6 +66,9 @@ class WaitForBlockResponse(StateInterface):
             return mutiny.states.reveal.resolve_reveal(data=self._data,
                                                        player_id=self._blocker_id,
                                                        action=self._action)
+
+    def can_allow(self, player_id: int) -> bool:
+        return not self._allow[player_id]
 
     def allow(self, player_id: int) -> StateInterface:
         # This is an invalid move because the blocker (from the NN) is able to allow his own block

--- a/mutiny/states/wait_for_block_response.py
+++ b/mutiny/states/wait_for_block_response.py
@@ -57,7 +57,7 @@ class WaitForBlockResponse(StateInterface):
         if (error := self.error_on_challenge(player_id)):
             raise InvalidMove(error)
 
-        # this is Treason-specific (you error_on lie about not having the influence in the og game)
+        # this is Treason-specific (you can lie about not having the influence in the og game)
         if self._data.players[self._blocker_id].hasAliveInfluence(self._block_role):
             self._data.deck.append(self._block_role)
             self._data.shuffle_deck()

--- a/test/states/test_exchange.py
+++ b/test/states/test_exchange.py
@@ -66,9 +66,13 @@ class TestExchange(unittest.TestCase):
                 })
 
         self.assertEqual(self.game._state_interface.__class__, Exchange)
+        new_cards = [role for role in self.game._state_interface.exchange_options]
+        for inf in self.game.game_data.active_player.hand:
+            if not inf.revealed:
+                new_cards.remove(inf.role)
         self.game.command(player_turn, self.game.game_data.state_id, {
                 "command" : CommandEnum.EXCHANGE,
-                "roles":  [i.value for i in self.game._state_interface.exchange_options],
+                "roles":  [card.value for card in new_cards],
                 "stateId" : self.game.game_data.state_id
                 })
 


### PR DESCRIPTION
Introduces functions of the form `error_on_X(params)`, which returns a string describing an error with the suggested operation, or `None` to signify `X(params)` is valid.

Error checking in `X` then looks like:
```
def X(params):
    if (error := self.error_on_X(params)):
        raise InvalidMove(error)

    """actual functionality of X"""
```
Note that `error:=self.error_on_X` uses the walrus operator, which assigns `error` to the right hand value, and returns the assigned variable. The walrus operator is a `python 3.8` feature 

This isn't used anywhere yet. `not bool(error_on_X(params))` can be used to check if `X(params)` is valid